### PR TITLE
Implement debugger buttons and build snes9x ex plus

### DIFF
--- a/EmuFramework/include/emuframework/AppKeyCode.hh
+++ b/EmuFramework/include/emuframework/AppKeyCode.hh
@@ -46,6 +46,8 @@ enum class AppKeyCode : KeyCode
 	hardReset,
 	resetMenu,
 	closeContent,
+	stepFrame,
+	breakEmulation,
 };
 
 constexpr struct AppKeys
@@ -69,7 +71,9 @@ constexpr struct AppKeys
 	softReset = KeyInfo::appKey(AppKeyCode::softReset),
 	hardReset = KeyInfo::appKey(AppKeyCode::hardReset),
 	resetMenu = KeyInfo::appKey(AppKeyCode::resetMenu),
-	exitApp = KeyInfo::appKey(AppKeyCode::exitApp);
+	exitApp = KeyInfo::appKey(AppKeyCode::exitApp),
+	stepFrame = KeyInfo::appKey(AppKeyCode::stepFrame),
+	breakEmulation = KeyInfo::appKey(AppKeyCode::breakEmulation);
 
 	constexpr const KeyInfo *data() const { return &openMenu; }
 	static constexpr size_t size() { return sizeof(AppKeys) / sizeof(KeyInfo); }
@@ -112,10 +116,14 @@ constexpr std::array genericKeyboardAppKeyCodeMap
 constexpr std::array rightUIKeys{appKeys.openMenu};
 constexpr std::array leftUIKeys{appKeys.toggleFastForward};
 constexpr std::array rewindUIKeys{appKeys.rewind};
+constexpr std::array stepUIKeys{appKeys.stepFrame};
+constexpr std::array breakUIKeys{appKeys.breakEmulation};
 
 constexpr InputComponentDesc rightUIComponents{"Open Menu", rightUIKeys, InputComponent::ui, RT2DO};
 constexpr InputComponentDesc leftUIComponents{"Toggle Fast-forward", leftUIKeys, InputComponent::ui, LT2DO};
 constexpr InputComponentDesc rewindUIComponents{"Rewind One State", rewindUIKeys, InputComponent::ui, LT2DO};
+constexpr InputComponentDesc stepUIComponents{"Step Frame", stepUIKeys, InputComponent::ui, RB2DO};
+constexpr InputComponentDesc breakUIComponents{"Break/Pause", breakUIKeys, InputComponent::ui, CB2DO};
 
 std::string_view toString(AppKeyCode);
 

--- a/EmuFramework/src/EmuInput.cc
+++ b/EmuFramework/src/EmuInput.cc
@@ -220,6 +220,38 @@ bool InputManager::handleAppActionKeyInput(EmuApp& app, InputAction action, cons
 			viewController.pushAndShowModal(resetAlertView(app.attachParams(), app), srcEvent, false);
 		}
 		break;
+		case breakEmulation:
+		{
+			if(!isPushed)
+				break;
+			// Toggle pause/resume of emulation
+			if(system.isPaused())
+			{
+				app.startEmulation();
+			}
+			else
+			{
+				app.pauseEmulation();
+			}
+			return true;
+		}
+		break;
+		case stepFrame:
+		{
+			if(!isPushed)
+				break;
+			// Advance a single frame when emulation is paused
+			if(system.isPaused())
+			{
+				auto suspendCtx = app.suspendEmulationThread();
+				// Run exactly one frame without audio (to avoid stutter)
+				app.runFrames({}, &app.video, nullptr, 1);
+				// Ensure the frame is presented
+				app.viewController().emuWindow().drawNow();
+				return true;
+			}
+		}
+		break;
 	}
 	return false;
 }
@@ -672,6 +704,8 @@ std::string_view toString(AppKeyCode code)
 		case AppKeyCode::softReset: return "Soft Reset";
 		case AppKeyCode::hardReset: return "Hard Reset";
 		case AppKeyCode::resetMenu: return "Open Reset Menu";
+		case AppKeyCode::breakEmulation: return "Break Emulation";
+		case AppKeyCode::stepFrame: return "Step Frame";
 	};
 	return "";
 }

--- a/EmuFramework/src/vcontrols/VController.cc
+++ b/EmuFramework/src/vcontrols/VController.cc
@@ -936,6 +936,9 @@ std::vector<VControllerElement> VController::defaultUIGroups() const
 	add(uiElements, rightUIComponents);
 	if(Config::Input::TOUCH_DEVICES)
 		add(uiElements, leftUIComponents);
+	add(uiElements, rewindUIComponents);
+	add(uiElements, breakUIComponents);
+	add(uiElements, stepUIComponents);
 	if(hasWindow())
 		resetUIPositions(uiElements);
 	return uiElements;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement "Break" and "Step" buttons in EmuInputView to enable debugger-like functionality.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
These new UI buttons allow users to pause/resume emulation and step through frames one by one, providing basic debugging capabilities.

---

[Open in Web](https://cursor.com/agents?id=bc-996eca46-49f6-4ce6-abe0-0c83a4096b92) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-996eca46-49f6-4ce6-abe0-0c83a4096b92) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)